### PR TITLE
Fix php warning about $ps['i']['att_id'] on Add New Member Error

### DIFF
--- a/www/php/controllers/AdminUsers.php
+++ b/www/php/controllers/AdminUsers.php
@@ -33,7 +33,7 @@ class AdminUsersController extends FwAdminController {
 
     public function ShowFormAction($form_id){
         $ps = parent::ShowFormAction($form_id);
-        $ps['att']= fw::model('Att')->one($ps['i']['att_id']+0);
+        $ps['att']= $ps['i']['att_id'] ? fw::model('Att')->one($ps['i']['att_id']+0) : '';
         return $ps;
     }
 


### PR DESCRIPTION
> Warning:  A non-numeric value encountered in  /home/www/osafw2/osafw-php/www/php/controllers/AdminUsers.php on line 36
