### PR TITLE
avoid warning on non existing $fw->GLOBAL['ERR']

### DIFF
--- a/www/php/fw/FwController.php
+++ b/www/php/fw/FwController.php
@@ -248,7 +248,7 @@ abstract class FwController {
         if ($this->fw->GLOBAL['ERR']['REQUIRED']){
             $result=false;
         }
-        if ( count($this->fw->GLOBAL['ERR']) && !$this->fw->GLOBAL['ERR']['REQUIRED'] ){
+        if ( is_array($this->fw->GLOBAL['ERR']) && !$this->fw->GLOBAL['ERR']['REQUIRED'] ){
             $this->setError('INVALID', true);
             $result=false;
         }

--- a/www/php/fw/FwController.php
+++ b/www/php/fw/FwController.php
@@ -248,7 +248,7 @@ abstract class FwController {
         if ($this->fw->GLOBAL['ERR']['REQUIRED']){
             $result=false;
         }
-        if ( is_array($this->fw->GLOBAL['ERR']) && !$this->fw->GLOBAL['ERR']['REQUIRED'] ){
+        if ( is_array($this->fw->GLOBAL['ERR']) && !empty($this->fw->GLOBAL['ERR']) && !$this->fw->GLOBAL['ERR']['REQUIRED'] ){
             $this->setError('INVALID', true);
             $result=false;
         }


### PR DESCRIPTION
GLOBAL['ERR'] array is created in case of errors only, so count produces warning.