### PR TITLE
Column names with dots in search

### DIFF
--- a/www/php/fw/FwController.php
+++ b/www/php/fw/FwController.php
@@ -221,9 +221,9 @@ abstract class FwController {
                 foreach ($afieldsand as $key2 => $fand) {
                     if (preg_match("/^\!/", $fand)){
                         $fand=preg_replace("/^\!/", "", $fand);
-                        $afieldsand[$key2]= $fand." = ".$exact_quoted;
+                        $afieldsand[$key2]= $this->db->quote_ident($fand)." = ".$exact_quoted;
                     }else{
-                        $afieldsand[$key2]= $fand." LIKE ".$like_quoted;
+                        $afieldsand[$key2]= $this->db->quote_ident($fand)." LIKE ".$like_quoted;
                     }
                 }
                 $afields[$key] = implode(' and ', $afieldsand);


### PR DESCRIPTION
it will not be excessive but will allow to use column names with dots, which is handy in views with many joins , i.e.:
```
SELECT 
        table1.iname,
        table2.iname AS `table2.iname`,
        table3.iname AS `table3.iname`,
        ...
```